### PR TITLE
Adjusted RSSI for Atheros.

### DIFF
--- a/package/network/utils/iwinfo/patches/102-add_atheros_backend.patch
+++ b/package/network/utils/iwinfo/patches/102-add_atheros_backend.patch
@@ -542,7 +542,7 @@ diff -Nuar temp_old/iwinfo_ath.c temp_new/iwinfo_ath.c
 +		memcpy( iwinfo_entry->mac , ieee80211_entry->isi_macaddr , 6 );
 +
 +
-+		iwinfo_entry->signal 			= -ieee80211_entry->isi_rssi;
++		iwinfo_entry->signal 			= ieee80211_entry->isi_rssi - 77;
 +		//iwinfo_entry->signal_avg		=;
 +		iwinfo_entry->noise				= -95;
 +		iwinfo_entry->inactive 			= ieee80211_entry->isi_inact;


### PR DESCRIPTION
The value being passed to iwinfo assoclist was the RSSI, not the signal strength in dBm. 
To fix this, the right calculation must be done and applied in the patch of iwinfo. 
A value of -77 was a good approximation to the real value, although it is not the perfect value.

This website explains more about it and the calculation, but the values not seems to fit for the qualcomm driver:
[RSSI / dBm Calculation](https://www.researchgate.net/file.PostFileLoader.html?id=55df0dd85cd9e3ee388b45d7&assetKey=AS:273840230338570@1442300006396)
